### PR TITLE
Create stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+# This workflow warns and then closes issues and PRs that have had no activity for a specified amount of time.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/actions/stale
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: '30 1 * * *'
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+
+    steps:
+    - uses: actions/stale@v5
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Stale issue message'
+        stale-pr-message: 'Stale pull request message'
+        stale-issue-label: 'no-issue-activity'
+        stale-pr-label: 'no-pr-activity'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,7 +18,7 @@ jobs:
       pull-requests: write
 
     steps:
-    - uses: actions/stale@v5
+    - uses: actions/stale@v9.1.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'Stale issue message'


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to help manage stale issues and pull requests by automatically warning and closing items that have had no activity for a specified period.

Automation and repository maintenance:

* Added `.github/workflows/stale.yml` to schedule a workflow that marks inactive issues and pull requests as stale, using the `actions/stale` GitHub Action. This includes configuration for messages, labels, and permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Added an automated workflow that runs daily to mark inactive issues and pull requests as stale, posting notifications and applying labels.
  - Uses distinct labels for issues and PRs (“no-issue-activity” and “no-pr-activity”) and has permissions to update and close threads.
  - Scheduled to run daily (early morning) to keep the issue/PR tracker current.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->