### PR TITLE
bump 1.4.32

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unicornstudio-react",
-  "version": "1.4.31",
+  "version": "1.4.32",
   "description": "React component for embedding Unicorn.Studio interactive scenes with TypeScript support. Compatible with React (Vite) and Next.js.",
   "keywords": [
     "react",

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,7 +1,7 @@
 import type { ValidFPS, ScaleRange } from "./types";
 
 // UnicornStudio configuration constants
-export const UNICORN_STUDIO_VERSION = "1.4.31";
+export const UNICORN_STUDIO_VERSION = "1.4.32";
 export const UNICORN_STUDIO_CDN_URL = `https://cdn.jsdelivr.net/gh/hiunicornstudio/unicornstudio.js@v${UNICORN_STUDIO_VERSION}/dist/unicornStudio.umd.js`;
 
 // Default values for UnicornScene props


### PR DESCRIPTION
v1.4.32
- Cancels raf properly when all scenes are destroyed
- Adds support for disabling text-as-html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Incremented application version to 1.4.32 across the project.
  * Updated version metadata to ensure asset URLs and references point to the 1.4.32 release.
  * No functional changes to features or user flows; behavior remains the same.
  * Maintains compatibility with existing integrations and configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->