### PR TITLE
Added custom script URL (sdkUrl) support for react/nextjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,17 @@ const constants = {
 
 **Warning**: Using a custom script URL may violate Unicorn.Studio's Terms of Service. Consult their legal terms before implementing.
 
+**React/Next.js Example usage:**
+
+```tsx
+<UnicornScene
+  projectId="YOUR_PROJECT_EMBED_ID"
+  sdkUrl="https://your-custom-cdn.com/unicornStudio.umd.js"
+  width={800}
+  height={600}
+/>
+```
+
 ### Browser Support
 
 - Chrome (latest)

--- a/src/next/index.tsx
+++ b/src/next/index.tsx
@@ -11,6 +11,7 @@ import { isWebGLSupported } from "../shared/utils";
 function UnicornScene({
   projectId,
   jsonFilePath,
+  sdkUrl = UNICORN_STUDIO_CDN_URL,
   width = DEFAULT_VALUES.width,
   height = DEFAULT_VALUES.height,
   scale = DEFAULT_VALUES.scale,
@@ -86,7 +87,7 @@ function UnicornScene({
   return (
     <>
       <Script
-        src={UNICORN_STUDIO_CDN_URL}
+        src={sdkUrl}
         strategy={lazyLoad ? "lazyOnload" : "afterInteractive"}
         onLoad={handleScriptLoad}
         onError={handleScriptError}

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -8,6 +8,7 @@ import { isWebGLSupported } from "../shared/utils";
 function UnicornScene({
   projectId,
   jsonFilePath,
+  sdkUrl = UNICORN_STUDIO_CDN_URL,
   width = DEFAULT_VALUES.width,
   height = DEFAULT_VALUES.height,
   scale = DEFAULT_VALUES.scale,
@@ -32,7 +33,7 @@ function UnicornScene({
   const {
     isLoaded,
     error: scriptError,
-  } = useUnicornStudioScript(UNICORN_STUDIO_CDN_URL);
+  } = useUnicornStudioScript(sdkUrl);
   
   const { error: sceneError } = useUnicornScene({
     elementRef,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -6,6 +6,7 @@ export type ScaleRange = number;
 export interface UnicornSceneProps {
   projectId?: string;
   jsonFilePath?: string;
+  sdkUrl?: string;
   altText?: string;
   width?: number | string;
   height?: number | string;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * UnicornScene now accepts an optional `sdkUrl` parameter, enabling users to load the SDK from a custom URL instead of the default CDN endpoint.

* **Documentation**
  * Added usage examples demonstrating how to configure and use a custom SDK URL with UnicornScene.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->