### PR TITLE
add pause flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ The component now supports flexible placeholder options that can be displayed wh
 | `className`                   | `string`                 | `""`      | Additional CSS classes                                                     |
 | `lazyLoad`                    | `boolean`                | `true`    | Load scene only when scrolled into view                                    |
 | `production`                  | `boolean`                | `true`    | Use production CDN                                                         |
+| `paused`                      | `boolean`                | `false`   | Pause or resume the scene animation                                        |
 | `placeholder`                 | `string \| ReactNode`    | -         | Placeholder content (image URL or React component)                         |
 | `placeholderClassName`        | `string`                 | -         | CSS classes for placeholder div (when using CSS placeholder)               |
 | `showPlaceholderOnError`      | `boolean`                | `true`    | Show placeholder when scene fails to load                                  |

--- a/src/next/index.tsx
+++ b/src/next/index.tsx
@@ -22,6 +22,7 @@ function UnicornScene({
   className = DEFAULT_VALUES.className,
   lazyLoad = DEFAULT_VALUES.lazyLoad,
   production = DEFAULT_VALUES.production,
+  paused = DEFAULT_VALUES.paused,
   placeholder,
   placeholderClassName,
   showPlaceholderOnError = DEFAULT_VALUES.showPlaceholderOnError,
@@ -51,6 +52,7 @@ function UnicornScene({
     altText,
     ariaLabel: ariaLabel || altText,
     isScriptLoaded: isLoaded,
+    paused,
     onLoad: () => {
       setIsSceneLoaded(true);
       onLoad?.();

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -19,6 +19,7 @@ function UnicornScene({
   className = DEFAULT_VALUES.className,
   lazyLoad = DEFAULT_VALUES.lazyLoad,
   production = DEFAULT_VALUES.production,
+  paused = DEFAULT_VALUES.paused,
   placeholder,
   placeholderClassName,
   showPlaceholderOnError = DEFAULT_VALUES.showPlaceholderOnError,
@@ -34,7 +35,7 @@ function UnicornScene({
     isLoaded,
     error: scriptError,
   } = useUnicornStudioScript(sdkUrl);
-  
+
   const { error: sceneError } = useUnicornScene({
     elementRef,
     projectId,
@@ -47,6 +48,7 @@ function UnicornScene({
     altText,
     ariaLabel: ariaLabel || altText,
     isScriptLoaded: isLoaded,
+    paused,
     onLoad: () => {
       setIsSceneLoaded(true);
       onLoad?.();

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -14,6 +14,7 @@ export const DEFAULT_VALUES = {
   fps: 60 as ValidFPS, // 15, 24, 30, 60, or 120
   altText: "Scene",
   className: "",
+  paused: false,
   lazyLoad: true,
   showPlaceholderOnError: true,
   showPlaceholderWhileLoading: true,

--- a/src/shared/hooks.ts
+++ b/src/shared/hooks.ts
@@ -20,6 +20,7 @@ export interface UseUnicornSceneParams {
   altText: string;
   ariaLabel: string;
   isScriptLoaded: boolean;
+  paused?: boolean;
   onLoad?: () => void;
   onError?: (error: Error) => void;
 }
@@ -36,6 +37,7 @@ export function useUnicornScene({
   altText,
   ariaLabel,
   isScriptLoaded,
+  paused,
   onLoad,
   onError,
 }: UseUnicornSceneParams) {
@@ -233,6 +235,13 @@ export function useUnicornScene({
       initializationKeyRef.current = ""; // Reset the key to allow fresh initialization
     }
   }, [projectId, jsonFilePath, scale, dpi, fps, production]);
+
+  // Sync paused state with scene
+  useEffect(() => {
+    if (sceneRef.current && paused !== undefined) {
+      sceneRef.current.paused = paused;
+    }
+  }, [paused]);
 
   return { error: initError };
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -17,6 +17,7 @@ export interface UnicornSceneProps {
   className?: string;
   lazyLoad?: boolean;
   production?: boolean;
+  paused?: boolean;
   placeholder?: string | React.ReactNode;
   placeholderClassName?: string;
   showPlaceholderOnError?: boolean;


### PR DESCRIPTION
The `Scene` class has a bool pause attribute which can be toggled. This introduces that flag to the component so the user can pause and unpause the scene's rendering. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added the ability to pause and resume scene animation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->