### PR TITLE
Add scene ref and bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## [2.1.4] - 2026-03-18
+
+### Added
+
+#### Scene Instance Ref Support
+
+- **New `sceneRef` prop**: Added support for passing a ref that receives the initialized Unicorn Studio scene instance
+  - Available in both the React and Next.js component exports
+  - Lets parent components interact with the live scene object after initialization
+  - Automatically clears the ref when the scene is destroyed or re-initialized
+
+### Usage Example
+
+```tsx
+import { useRef } from "react";
+import UnicornScene, { type UnicornStudioScene } from "unicornstudio-react";
+
+export default function MyComponent() {
+  const sceneRef = useRef<UnicornStudioScene | null>(null);
+
+  return (
+    <>
+      <UnicornScene
+        projectId="YOUR_PROJECT_EMBED_ID"
+        width={800}
+        height={600}
+        sceneRef={sceneRef}
+      />
+
+      <button onClick={() => sceneRef.current?.resize?.()}>Resize</button>
+      <button
+        onClick={() => {
+          if (sceneRef.current) {
+            sceneRef.current.paused = true;
+          }
+        }}
+      >
+        Pause
+      </button>
+    </>
+  );
+}
+```
+
+### Documentation
+
+- Added README documentation for the new `sceneRef` prop
+- Documented example scene controls using `scene.resize()` and `scene.paused = true`
+
+### Internal
+
+- Updated the Unicorn Studio SDK version from `2.1.1` to `2.1.4`
+- Synced the shared scene lifecycle hook with external refs while preserving cleanup behavior
+
 ## [1.4.33-1] - 2025-10-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -144,6 +144,45 @@ export default function MyComponent() {
 }
 ```
 
+### Accessing the Scene Instance
+
+Use the `sceneRef` prop when you want access to the underlying Unicorn Studio scene object after it initializes.
+
+```tsx
+import { useRef } from "react";
+import UnicornScene, { type UnicornStudioScene } from "unicornstudio-react";
+
+export default function MyComponent() {
+  const sceneRef = useRef<UnicornStudioScene | null>(null);
+
+  const pauseScene = () => {
+    if (sceneRef.current) {
+      sceneRef.current.paused = true;
+    }
+  };
+
+  const resizeScene = () => {
+    sceneRef.current?.resize?.();
+  };
+
+  return (
+    <>
+      <UnicornScene
+        projectId="YOUR_PROJECT_EMBED_ID"
+        width={800}
+        height={600}
+        sceneRef={sceneRef}
+      />
+
+      <button onClick={pauseScene}>Pause</button>
+      <button onClick={resizeScene}>Resize</button>
+    </>
+  );
+}
+```
+
+The `sceneRef` value is assigned once the scene finishes loading and is cleared automatically if the scene is destroyed or re-initialized.
+
 ## Placeholder Support
 
 The component now supports flexible placeholder options that can be displayed while loading, on error, or when WebGL is not supported.
@@ -217,6 +256,7 @@ The component now supports flexible placeholder options that can be displayed wh
 | `showPlaceholderWhileLoading` | `boolean`                | `true`    | Show placeholder while scene is loading                                    |
 | `onLoad`                      | `() => void`             | -         | Callback when scene loads successfully                                     |
 | `onError`                     | `(error: Error) => void` | -         | Callback when scene fails to load                                          |
+| `sceneRef`                    | `Ref<UnicornStudioScene \| null>` | - | Ref that receives the initialized Unicorn Studio scene instance            |
 
 ## Styling
 

--- a/src/next/index.tsx
+++ b/src/next/index.tsx
@@ -81,6 +81,7 @@ function UnicornScene({
   showPlaceholderWhileLoading = DEFAULT_VALUES.showPlaceholderWhileLoading,
   onLoad,
   onError,
+  sceneRef,
 }: UnicornSceneProps) {
   const elementRef = useRef<HTMLDivElement>(null);
   const [isSceneLoaded, setIsSceneLoaded] = useState(false);
@@ -105,6 +106,7 @@ function UnicornScene({
     ariaLabel: ariaLabel || altText,
     isScriptLoaded: isLoaded,
     paused,
+    sceneRef,
     onLoad: () => {
       setIsSceneLoaded(true);
       onLoad?.();

--- a/src/react/index.tsx
+++ b/src/react/index.tsx
@@ -69,6 +69,7 @@ function UnicornScene({
   showPlaceholderWhileLoading = DEFAULT_VALUES.showPlaceholderWhileLoading,
   onLoad,
   onError,
+  sceneRef,
 }: UnicornSceneProps) {
   const elementRef = useRef<HTMLDivElement>(null);
   const [isSceneLoaded, setIsSceneLoaded] = useState(false);
@@ -92,6 +93,7 @@ function UnicornScene({
     ariaLabel: ariaLabel || altText,
     isScriptLoaded: isLoaded,
     paused,
+    sceneRef,
     onLoad: () => {
       setIsSceneLoaded(true);
       onLoad?.();

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -3,7 +3,7 @@ import type { ValidFPS, ScaleRange } from "./types";
 /**
  * Current version of the Unicorn Studio SDK being used.
  */
-export const UNICORN_STUDIO_VERSION = "2.1.1";
+export const UNICORN_STUDIO_VERSION = "2.1.4";
 
 /**
  * CDN URL for the Unicorn Studio SDK script.

--- a/src/shared/hooks.ts
+++ b/src/shared/hooks.ts
@@ -82,6 +82,28 @@ export interface UseUnicornSceneParams {
    * @param error - The error that occurred
    */
   onError?: (error: Error) => void;
+
+  /**
+   * Optional ref that receives the active Unicorn Studio scene instance.
+   */
+  sceneRef?: React.Ref<UnicornStudioScene | null>;
+}
+
+/**
+ * Keeps an external ref in sync with the current scene instance.
+ */
+function assignSceneRef(
+  ref: React.Ref<UnicornStudioScene | null> | undefined,
+  value: UnicornStudioScene | null
+) {
+  if (!ref) return;
+
+  if (typeof ref === "function") {
+    ref(value);
+    return;
+  }
+
+  (ref as React.MutableRefObject<UnicornStudioScene | null>).current = value;
 }
 
 /**
@@ -132,8 +154,9 @@ export function useUnicornScene({
   paused,
   onLoad,
   onError,
+  sceneRef,
 }: UseUnicornSceneParams): { error: Error | null } {
-  const sceneRef = useRef<UnicornStudioScene | null>(null);
+  const internalSceneRef = useRef<UnicornStudioScene | null>(null);
   const [initError, setInitError] = useState<Error | null>(null);
   const hasAttemptedRef = useRef(false);
   const initializationKeyRef = useRef<string>("");
@@ -161,12 +184,13 @@ export function useUnicornScene({
   }, [validationError, onError]);
 
   const destroyScene = useCallback(() => {
-    if (sceneRef.current?.destroy) {
-      sceneRef.current.destroy();
-      sceneRef.current = null;
+    if (internalSceneRef.current?.destroy) {
+      internalSceneRef.current.destroy();
+      internalSceneRef.current = null;
+      assignSceneRef(sceneRef, null);
     }
     isInitializingRef.current = false;
-  }, []);
+  }, [sceneRef]);
 
   const initializeScene = useCallback(async () => {
     if (!elementRef.current || !isScriptLoaded || validationError) return;
@@ -181,7 +205,7 @@ export function useUnicornScene({
     const currentKey = `${projectId || ""}-${jsonFilePath || ""}-${scale}-${dpi}-${fps}-${production ? "prod" : "dev"}`;
 
     // Check if we're already initialized with this exact configuration
-    if (initializationKeyRef.current === currentKey && sceneRef.current) {
+    if (initializationKeyRef.current === currentKey && internalSceneRef.current) {
       console.log(
         "Scene already initialized with this configuration, skipping..."
       );
@@ -253,7 +277,9 @@ export function useUnicornScene({
         cleanup();
 
         if (scene) {
-          sceneRef.current = scene;
+          internalSceneRef.current = scene;
+          // Expose the latest scene instance so parent components can use it.
+          assignSceneRef(sceneRef, scene);
           hasAttemptedRef.current = false; // Reset on success
           setInitError(null); // Clear any previous errors
           isInitializingRef.current = false;
@@ -305,6 +331,7 @@ export function useUnicornScene({
     destroyScene,
     onLoad,
     onError,
+    sceneRef,
     validationError,
   ]);
 
@@ -332,8 +359,8 @@ export function useUnicornScene({
 
   // Sync paused state with scene
   useEffect(() => {
-    if (sceneRef.current && paused !== undefined) {
-      sceneRef.current.paused = paused;
+    if (internalSceneRef.current && paused !== undefined) {
+      internalSceneRef.current.paused = paused;
     }
   }, [paused]);
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -167,6 +167,15 @@ export interface UnicornSceneProps {
    * @param error - The error that occurred
    */
   onError?: (error: Error) => void;
+
+  /**
+   * Optional ref that receives the initialized Unicorn Studio scene instance.
+   *
+   * @remarks
+   * This is set after the scene finishes initializing and cleared when the
+   * scene is destroyed or re-initialized.
+   */
+  sceneRef?: React.Ref<UnicornStudioScene | null>;
 }
 
 /**


### PR DESCRIPTION
### Added

#### Scene Instance Ref Support

- **New `sceneRef` prop**: Added support for passing a ref that receives the initialized Unicorn Studio scene instance
  - Available in both the React and Next.js component exports
  - Lets parent components interact with the live scene object after initialization
  - Automatically clears the ref when the scene is destroyed or re-initialized

### Usage Example

```tsx
import { useRef } from "react";
import UnicornScene, { type UnicornStudioScene } from "unicornstudio-react";

export default function MyComponent() {
  const sceneRef = useRef<UnicornStudioScene | null>(null);

  return (
    <>
      <UnicornScene
        projectId="YOUR_PROJECT_EMBED_ID"
        width={800}
        height={600}
        sceneRef={sceneRef}
      />

      <button onClick={() => sceneRef.current?.resize?.()}>Resize</button>
      <button
        onClick={() => {
          if (sceneRef.current) {
            sceneRef.current.paused = true;
          }
        }}
      >
        Pause
      </button>
    </>
  );
}
```

### Documentation

- Added README documentation for the new `sceneRef` prop
- Documented example scene controls using `scene.resize()` and `scene.paused = true`

### Internal

- Updated the Unicorn Studio SDK version from `2.1.1` to `2.1.4`
- Synced the shared scene lifecycle hook with external refs while preserving cleanup behavior

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `sceneRef` prop to UnicornScene component, providing direct access to the initialized Unicorn Studio scene instance for interactive control and manipulation.

* **Documentation**
  * Updated guides with usage examples demonstrating how to interact with the scene reference, including lifecycle behavior details for load and destruction events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->