### PR TITLE
 Fix duplicate canvas in React Strict Mode

### DIFF
--- a/src/shared/hooks.ts
+++ b/src/shared/hooks.ts
@@ -336,15 +336,23 @@ export function useUnicornScene({
   ]);
 
   useEffect(() => {
-    if (isScriptLoaded) {
-      void initializeScene();
-    }
-  }, [isScriptLoaded, initializeScene]);
+    let aborted = false;
 
-  // Cleanup only on unmount
-  useEffect(() => {
-    return destroyScene;
-  }, [destroyScene]);
+    if (isScriptLoaded) {
+      void initializeScene().then(() => {
+        if (aborted && internalSceneRef.current?.destroy) {
+          internalSceneRef.current.destroy();
+          internalSceneRef.current = null;
+          assignSceneRef(sceneRef, null);
+        }
+      });
+    }
+
+    return () => {
+      aborted = true;
+      destroyScene();
+    };
+  }, [isScriptLoaded, initializeScene, destroyScene, sceneRef]);
 
   // Reset state when projectId or jsonFilePath changes
   useEffect(() => {

--- a/src/shared/hooks.ts
+++ b/src/shared/hooks.ts
@@ -162,6 +162,14 @@ export function useUnicornScene({
   const initializationKeyRef = useRef<string>("");
   const isInitializingRef = useRef(false);
 
+  // Stable refs for callbacks and sceneRef so they never trigger re-initialization
+  const onLoadRef = useRef(onLoad);
+  onLoadRef.current = onLoad;
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+  const sceneRefRef = useRef(sceneRef);
+  sceneRefRef.current = sceneRef;
+
   // Validate parameters early and memoize the result to prevent loops
   const validationError = useMemo(() => {
     return validateParameters(scale, fps);
@@ -176,21 +184,21 @@ export function useUnicornScene({
       if (validationError) {
         const error = new Error(validationError);
         setInitError(error);
-        onError?.(error);
+        onErrorRef.current?.(error);
       } else {
         setInitError(null);
       }
     }
-  }, [validationError, onError]);
+  }, [validationError]);
 
   const destroyScene = useCallback(() => {
     if (internalSceneRef.current?.destroy) {
       internalSceneRef.current.destroy();
       internalSceneRef.current = null;
-      assignSceneRef(sceneRef, null);
+      assignSceneRef(sceneRefRef.current, null);
     }
     isInitializingRef.current = false;
-  }, [sceneRef]);
+  }, []);
 
   useEffect(() => {
     let ignore = false;
@@ -251,7 +259,7 @@ export function useUnicornScene({
         }
 
         // Initialize with a timeout to prevent infinite retries
-        let timeoutId: NodeJS.Timeout | undefined;
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
         const timeoutPromise = new Promise<never>((_, reject) => {
           timeoutId = setTimeout(
             () => reject(new Error("Scene initialization timeout")),
@@ -279,11 +287,11 @@ export function useUnicornScene({
 
           if (scene) {
             internalSceneRef.current = scene;
-            assignSceneRef(sceneRef, scene);
+            assignSceneRef(sceneRefRef.current, scene);
             hasAttemptedRef.current = false;
             setInitError(null);
             isInitializingRef.current = false;
-            onLoad?.();
+            onLoadRef.current?.();
           } else {
             isInitializingRef.current = false;
             throw new Error("Failed to initialize scene");
@@ -317,7 +325,7 @@ export function useUnicornScene({
         const sanitizedError = new Error(sanitizedMessage);
         setInitError(sanitizedError);
         isInitializingRef.current = false;
-        onError?.(sanitizedError);
+        onErrorRef.current?.(sanitizedError);
       }
     }
 
@@ -342,9 +350,6 @@ export function useUnicornScene({
     altText,
     ariaLabel,
     destroyScene,
-    onLoad,
-    onError,
-    sceneRef,
     validationError,
   ]);
 

--- a/src/shared/hooks.ts
+++ b/src/shared/hooks.ts
@@ -192,133 +192,146 @@ export function useUnicornScene({
     isInitializingRef.current = false;
   }, [sceneRef]);
 
-  const initializeScene = useCallback(async () => {
-    if (!elementRef.current || !isScriptLoaded || validationError) return;
+  useEffect(() => {
+    let ignore = false;
 
-    // Prevent multiple concurrent initializations
-    if (isInitializingRef.current) {
-      console.log("Already initializing, skipping...");
-      return;
-    }
+    async function initializeScene() {
+      if (!elementRef.current || !isScriptLoaded || validationError) return;
 
-    // Create a unique key for this configuration
-    const currentKey = `${projectId || ""}-${jsonFilePath || ""}-${scale}-${dpi}-${fps}-${production ? "prod" : "dev"}`;
+      // Prevent multiple concurrent initializations
+      if (isInitializingRef.current) return;
 
-    // Check if we're already initialized with this exact configuration
-    if (initializationKeyRef.current === currentKey && internalSceneRef.current) {
-      console.log(
-        "Scene already initialized with this configuration, skipping..."
-      );
-      return;
-    }
+      // Create a unique key for this configuration
+      const currentKey = `${projectId || ""}-${jsonFilePath || ""}-${scale}-${dpi}-${fps}-${production ? "prod" : "dev"}`;
 
-    // Update the initialization key and flag
-    initializationKeyRef.current = currentKey;
-    hasAttemptedRef.current = true;
-    isInitializingRef.current = true;
-
-    try {
-      destroyScene();
-      // Check if UnicornStudio is available
-      if (!window.UnicornStudio?.addScene) {
-        throw new Error("UnicornStudio.addScene not found");
+      // Check if we're already initialized with this exact configuration
+      if (
+        initializationKeyRef.current === currentKey &&
+        internalSceneRef.current
+      ) {
+        return;
       }
 
-      // Prepare scene configuration
-      const sceneConfig: UnicornSceneConfig = {
-        elementId:
-          elementRef.current.id ||
-          `unicorn-${Math.random().toString(36).slice(2, 11)}`,
-        scale,
-        dpi,
-        fps,
-        lazyLoad,
-        altText,
-        ariaLabel,
-        production,
-      };
-
-      // Set the ID if it doesn't exist
-      if (!elementRef.current.id) {
-        elementRef.current.id = sceneConfig.elementId;
-      }
-
-      // Add project source
-      if (jsonFilePath) {
-        sceneConfig.filePath = jsonFilePath;
-      } else if (projectId) {
-        sceneConfig.projectId = projectId;
-      } else {
-        throw new Error("No project ID or JSON file path provided");
-      }
-
-      // Initialize the scene using the dynamic method with a timeout
-      // This prevents infinite retries from the Unicorn Studio library
-      let timeoutId: NodeJS.Timeout | undefined;
-      const timeoutPromise = new Promise<never>((_, reject) => {
-        timeoutId = setTimeout(
-          () => reject(new Error("Scene initialization timeout")),
-          15000
-        );
-      });
-
-      const cleanup = () => {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
-      };
+      // Update the initialization key and flag
+      initializationKeyRef.current = currentKey;
+      hasAttemptedRef.current = true;
+      isInitializingRef.current = true;
 
       try {
-        const scene = await Promise.race([
-          window.UnicornStudio.addScene(sceneConfig),
-          timeoutPromise,
-        ]);
+        destroyScene();
 
-        cleanup();
+        if (!window.UnicornStudio?.addScene) {
+          throw new Error("UnicornStudio.addScene not found");
+        }
 
-        if (scene) {
-          internalSceneRef.current = scene;
-          // Expose the latest scene instance so parent components can use it.
-          assignSceneRef(sceneRef, scene);
-          hasAttemptedRef.current = false; // Reset on success
-          setInitError(null); // Clear any previous errors
-          isInitializingRef.current = false;
-          onLoad?.();
+        // Prepare scene configuration
+        const sceneConfig: UnicornSceneConfig = {
+          elementId:
+            elementRef.current.id ||
+            `unicorn-${Math.random().toString(36).slice(2, 11)}`,
+          scale,
+          dpi,
+          fps,
+          lazyLoad,
+          altText,
+          ariaLabel,
+          production,
+        };
+
+        if (!elementRef.current.id) {
+          elementRef.current.id = sceneConfig.elementId;
+        }
+
+        if (jsonFilePath) {
+          sceneConfig.filePath = jsonFilePath;
+        } else if (projectId) {
+          sceneConfig.projectId = projectId;
         } else {
-          isInitializingRef.current = false;
-          throw new Error("Failed to initialize scene");
+          throw new Error("No project ID or JSON file path provided");
+        }
+
+        // Initialize with a timeout to prevent infinite retries
+        let timeoutId: NodeJS.Timeout | undefined;
+        const timeoutPromise = new Promise<never>((_, reject) => {
+          timeoutId = setTimeout(
+            () => reject(new Error("Scene initialization timeout")),
+            15000
+          );
+        });
+
+        const clearTimer = () => {
+          if (timeoutId) clearTimeout(timeoutId);
+        };
+
+        try {
+          const scene = await Promise.race([
+            window.UnicornStudio.addScene(sceneConfig),
+            timeoutPromise,
+          ]);
+
+          clearTimer();
+
+          // If the effect cleaned up while we were awaiting, destroy and bail
+          if (ignore) {
+            scene?.destroy();
+            return;
+          }
+
+          if (scene) {
+            internalSceneRef.current = scene;
+            assignSceneRef(sceneRef, scene);
+            hasAttemptedRef.current = false;
+            setInitError(null);
+            isInitializingRef.current = false;
+            onLoad?.();
+          } else {
+            isInitializingRef.current = false;
+            throw new Error("Failed to initialize scene");
+          }
+        } catch (error) {
+          clearTimer();
+          throw error;
         }
       } catch (error) {
-        cleanup();
-        throw error;
-      }
-    } catch (error) {
-      const err = error instanceof Error ? error : new Error("Unknown error");
+        if (ignore) return;
 
-      // Sanitize error messages to not expose URLs
-      let sanitizedMessage = err.message;
-      if (
-        sanitizedMessage.includes("404") ||
-        sanitizedMessage.includes("Failed to fetch")
-      ) {
-        sanitizedMessage = "Resource not found";
-      } else if (
-        sanitizedMessage.includes("Network") ||
-        sanitizedMessage.includes("network")
-      ) {
-        sanitizedMessage = "Network error occurred";
-      } else if (sanitizedMessage.includes("timeout")) {
-        sanitizedMessage = "Loading timeout";
-      }
+        const err =
+          error instanceof Error ? error : new Error("Unknown error");
 
-      const sanitizedError = new Error(sanitizedMessage);
-      setInitError(sanitizedError);
-      isInitializingRef.current = false;
-      onError?.(sanitizedError);
+        // Sanitize error messages to not expose URLs
+        let sanitizedMessage = err.message;
+        if (
+          sanitizedMessage.includes("404") ||
+          sanitizedMessage.includes("Failed to fetch")
+        ) {
+          sanitizedMessage = "Resource not found";
+        } else if (
+          sanitizedMessage.includes("Network") ||
+          sanitizedMessage.includes("network")
+        ) {
+          sanitizedMessage = "Network error occurred";
+        } else if (sanitizedMessage.includes("timeout")) {
+          sanitizedMessage = "Loading timeout";
+        }
+
+        const sanitizedError = new Error(sanitizedMessage);
+        setInitError(sanitizedError);
+        isInitializingRef.current = false;
+        onError?.(sanitizedError);
+      }
     }
+
+    if (isScriptLoaded) {
+      void initializeScene();
+    }
+
+    return () => {
+      ignore = true;
+      destroyScene();
+    };
   }, [
-    elementRef,
     isScriptLoaded,
+    elementRef,
     jsonFilePath,
     projectId,
     production,
@@ -334,36 +347,6 @@ export function useUnicornScene({
     sceneRef,
     validationError,
   ]);
-
-  useEffect(() => {
-    let aborted = false;
-
-    if (isScriptLoaded) {
-      void initializeScene().then(() => {
-        if (aborted && internalSceneRef.current?.destroy) {
-          internalSceneRef.current.destroy();
-          internalSceneRef.current = null;
-          assignSceneRef(sceneRef, null);
-        }
-      });
-    }
-
-    return () => {
-      aborted = true;
-      destroyScene();
-    };
-  }, [isScriptLoaded, initializeScene, destroyScene, sceneRef]);
-
-  // Reset state when projectId or jsonFilePath changes
-  useEffect(() => {
-    const newKey = `${projectId || ""}-${jsonFilePath || ""}-${scale}-${dpi}-${fps}-${production ? "prod" : "dev"}`;
-    if (initializationKeyRef.current !== newKey) {
-      hasAttemptedRef.current = false;
-      setInitError(null);
-      isInitializingRef.current = false;
-      initializationKeyRef.current = ""; // Reset the key to allow fresh initialization
-    }
-  }, [projectId, jsonFilePath, scale, dpi, fps, production]);
 
   // Sync paused state with scene
   useEffect(() => {


### PR DESCRIPTION
 **Summary**

  - Fix race condition where async addScene from the first mount resolves after
  Strict Mode cleanup, creating a stale canvas that never gets destroyed
  - Combine initialization and cleanup into a single useEffect with a local
  aborted flag that catches late-resolving promises

  Fixes #35 

  **Test plan**

  - Run dev app with React Strict Mode enabled and verify only one canvas
  element is rendered
  - Verify scene initializes correctly in production (non-Strict Mode) builds
  - Verify cleanup on unmount still works (navigate away and back)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stabilized callback tracking to ensure handlers always use the latest values.
  * Improved error reporting and safer scene assignment.
  * Consolidated initialization into a single lifecycle effect with short-circuiting to avoid acting after cleanup.
  * Ensured created scenes are destroyed and timers cleared during teardown to prevent leaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->