### PR TITLE
Add ResizeObserver support to useUnicornScene hook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ yarn-error.log*
 .vscode/
 .idea/
 
+# Playground
+playground/
+
 # TypeScript
 *.tsbuildinfo
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "unicornstudio-react",
-  "version": "2.1.4",
+  "version": "2.1.4-1",
   "description": "React component for embedding Unicorn.Studio interactive scenes with TypeScript support. Compatible with React (Vite) and Next.js.",
   "keywords": [
     "react",

--- a/src/__tests__/next-component.test.tsx
+++ b/src/__tests__/next-component.test.tsx
@@ -57,9 +57,17 @@ describe("UnicornScene (Next.js)", () => {
   });
 
   it("passes sdkUrl to the Script component", () => {
-    render(<UnicornScene projectId="test-id" sdkUrl="https://custom-cdn.example.com/sdk.js" />);
+    render(
+      <UnicornScene
+        projectId="test-id"
+        sdkUrl="https://custom-cdn.example.com/sdk.js"
+      />,
+    );
     const script = screen.getByTestId("next-script");
-    expect(script).toHaveAttribute("src", "https://custom-cdn.example.com/sdk.js");
+    expect(script).toHaveAttribute(
+      "src",
+      "https://custom-cdn.example.com/sdk.js",
+    );
   });
 
   it("uses lazyOnload strategy when lazyLoad is true", () => {

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,1 +1,38 @@
 import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+// jsdom does not provide ResizeObserver — provide a minimal mock that tracks
+// observed elements and exposes a helper to simulate resize entries.
+type ResizeCallback = (entries: ResizeObserverEntry[]) => void;
+
+class MockResizeObserver {
+  static instances: MockResizeObserver[] = [];
+
+  callback: ResizeCallback;
+  elements: Set<Element> = new Set();
+
+  constructor(callback: ResizeCallback) {
+    this.callback = callback;
+    MockResizeObserver.instances.push(this);
+  }
+
+  observe(target: Element) {
+    this.elements.add(target);
+  }
+  unobserve(target: Element) {
+    this.elements.delete(target);
+  }
+  disconnect = vi.fn(() => {
+    this.elements.clear();
+  });
+
+  /** Test helper: fire the callback with a minimal entry for `target`. */
+  simulateResize(target: Element) {
+    const entry = { target } as ResizeObserverEntry;
+    this.callback([entry]);
+  }
+}
+
+vi.stubGlobal("ResizeObserver", MockResizeObserver);
+
+export { MockResizeObserver };

--- a/src/__tests__/useUnicornScene.test.ts
+++ b/src/__tests__/useUnicornScene.test.ts
@@ -646,6 +646,30 @@ describe("useUnicornScene", () => {
     expect(observer!.disconnect).toHaveBeenCalled();
   });
 
+  it("degrades gracefully when ResizeObserver is unavailable", async () => {
+    const originalResizeObserver = globalThis.ResizeObserver;
+    // @ts-expect-error -- simulating an environment without ResizeObserver
+    delete globalThis.ResizeObserver;
+
+    try {
+      addSceneMock.mockResolvedValueOnce(createMockScene({ resize: vi.fn() }));
+
+      const { unmount } = renderHook(() =>
+        useUnicornScene(defaultProps(elementRef)),
+      );
+
+      await act(async () => {});
+
+      // No ResizeObserver should have been created
+      expect(MockResizeObserver.instances).toHaveLength(0);
+
+      // Should not throw on unmount either
+      expect(() => unmount()).not.toThrow();
+    } finally {
+      globalThis.ResizeObserver = originalResizeObserver;
+    }
+  });
+
   it("does not create a ResizeObserver when elementRef is null", async () => {
     const instancesBefore = MockResizeObserver.instances.length;
 
@@ -657,7 +681,10 @@ describe("useUnicornScene", () => {
     );
 
     await act(async () => {});
-    expect(MockResizeObserver.instances).toHaveLength(instancesBefore);
+
+    const newObservers = MockResizeObserver.instances.slice(instancesBefore);
+    const observersWithElements = newObservers.filter(
+      (o) => o.elements.size > 0,
     );
     expect(observersWithElements).toHaveLength(0);
   });

--- a/src/__tests__/useUnicornScene.test.ts
+++ b/src/__tests__/useUnicornScene.test.ts
@@ -657,11 +657,7 @@ describe("useUnicornScene", () => {
     );
 
     await act(async () => {});
-
-    // No new observer should have been created for a null element
-    const newObservers = MockResizeObserver.instances.slice(instancesBefore);
-    const observersWithElements = newObservers.filter(
-      (o) => o.elements.size > 0,
+    expect(MockResizeObserver.instances).toHaveLength(instancesBefore);
     );
     expect(observersWithElements).toHaveLength(0);
   });

--- a/src/__tests__/useUnicornScene.test.ts
+++ b/src/__tests__/useUnicornScene.test.ts
@@ -619,9 +619,11 @@ describe("useUnicornScene", () => {
     );
 
     // Should not throw when resize is undefined
-    act(() => {
-      observer!.simulateResize(containerEl);
-    });
+    expect(() => {
+      act(() => {
+        observer!.simulateResize(containerEl);
+      });
+    }).not.toThrow();
   });
 
   it("disconnects the ResizeObserver on unmount", async () => {

--- a/src/__tests__/useUnicornScene.test.ts
+++ b/src/__tests__/useUnicornScene.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useUnicornScene } from "../shared/hooks";
 import type { UnicornStudioScene } from "../shared/types";
+import { MockResizeObserver } from "./setup";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -62,6 +63,7 @@ describe("useUnicornScene", () => {
     vi.restoreAllMocks();
     delete (window as Record<string, unknown>).UnicornStudio;
     containerEl.remove();
+    MockResizeObserver.instances.length = 0;
   });
 
   // -----------------------------------------------------------------------
@@ -103,9 +105,7 @@ describe("useUnicornScene", () => {
     addSceneMock.mockResolvedValueOnce(scene);
     const onLoad = vi.fn();
 
-    renderHook(() =>
-      useUnicornScene({ ...defaultProps(elementRef), onLoad }),
-    );
+    renderHook(() => useUnicornScene({ ...defaultProps(elementRef), onLoad }));
 
     await act(async () => {});
 
@@ -135,10 +135,9 @@ describe("useUnicornScene", () => {
     const scene = createMockScene();
     addSceneMock.mockResolvedValue(scene);
 
-    const { rerender } = renderHook(
-      (props) => useUnicornScene(props),
-      { initialProps: { ...defaultProps(elementRef), onLoad: () => {} } },
-    );
+    const { rerender } = renderHook((props) => useUnicornScene(props), {
+      initialProps: { ...defaultProps(elementRef), onLoad: () => {} },
+    });
 
     await act(async () => {});
     expect(addSceneMock).toHaveBeenCalledTimes(1);
@@ -160,10 +159,9 @@ describe("useUnicornScene", () => {
     const scene2 = createMockScene();
     addSceneMock.mockResolvedValueOnce(scene1).mockResolvedValueOnce(scene2);
 
-    const { rerender } = renderHook(
-      (props) => useUnicornScene(props),
-      { initialProps: defaultProps(elementRef) },
-    );
+    const { rerender } = renderHook((props) => useUnicornScene(props), {
+      initialProps: defaultProps(elementRef),
+    });
 
     await act(async () => {});
     expect(addSceneMock).toHaveBeenCalledTimes(1);
@@ -206,14 +204,16 @@ describe("useUnicornScene", () => {
     let resolveFirst!: (s: UnicornStudioScene) => void;
     addSceneMock
       .mockImplementationOnce(
-        () => new Promise<UnicornStudioScene>((r) => { resolveFirst = r; }),
+        () =>
+          new Promise<UnicornStudioScene>((r) => {
+            resolveFirst = r;
+          }),
       )
       .mockResolvedValueOnce(createMockScene());
 
-    const { rerender } = renderHook(
-      (props) => useUnicornScene(props),
-      { initialProps: defaultProps(elementRef) },
-    );
+    const { rerender } = renderHook((props) => useUnicornScene(props), {
+      initialProps: defaultProps(elementRef),
+    });
 
     await act(async () => {});
     expect(addSceneMock).toHaveBeenCalledTimes(1);
@@ -226,7 +226,9 @@ describe("useUnicornScene", () => {
 
     // Resolve the first (its ignore flag is set, so the scene gets destroyed)
     const lateScene = createMockScene();
-    await act(async () => { resolveFirst(lateScene); });
+    await act(async () => {
+      resolveFirst(lateScene);
+    });
     expect(lateScene.destroy).toHaveBeenCalled();
   });
 
@@ -279,15 +281,12 @@ describe("useUnicornScene", () => {
     const oldRef: { current: UnicornStudioScene | null } = { current: null };
     const newRef: { current: UnicornStudioScene | null } = { current: null };
 
-    const { rerender } = renderHook(
-      (props) => useUnicornScene(props),
-      {
-        initialProps: {
-          ...defaultProps(elementRef),
-          sceneRef: oldRef,
-        },
+    const { rerender } = renderHook((props) => useUnicornScene(props), {
+      initialProps: {
+        ...defaultProps(elementRef),
+        sceneRef: oldRef,
       },
-    );
+    });
 
     await act(async () => {});
     expect(oldRef.current).toBe(scene);
@@ -307,15 +306,12 @@ describe("useUnicornScene", () => {
     const oldRefFn = vi.fn();
     const newRefFn = vi.fn();
 
-    const { rerender } = renderHook(
-      (props) => useUnicornScene(props),
-      {
-        initialProps: {
-          ...defaultProps(elementRef),
-          sceneRef: oldRefFn,
-        },
+    const { rerender } = renderHook((props) => useUnicornScene(props), {
+      initialProps: {
+        ...defaultProps(elementRef),
+        sceneRef: oldRefFn,
       },
-    );
+    });
 
     await act(async () => {});
     expect(oldRefFn).toHaveBeenCalledWith(scene);
@@ -337,10 +333,9 @@ describe("useUnicornScene", () => {
     const scene = createMockScene({ paused: false });
     addSceneMock.mockResolvedValueOnce(scene);
 
-    const { rerender } = renderHook(
-      (props) => useUnicornScene(props),
-      { initialProps: { ...defaultProps(elementRef), paused: false } },
-    );
+    const { rerender } = renderHook((props) => useUnicornScene(props), {
+      initialProps: { ...defaultProps(elementRef), paused: false },
+    });
 
     await act(async () => {});
 
@@ -407,7 +402,10 @@ describe("useUnicornScene", () => {
     const scene = createMockScene();
     let resolveAddScene!: (s: UnicornStudioScene) => void;
     addSceneMock.mockImplementationOnce(
-      () => new Promise<UnicornStudioScene>((r) => { resolveAddScene = r; }),
+      () =>
+        new Promise<UnicornStudioScene>((r) => {
+          resolveAddScene = r;
+        }),
     );
 
     const { unmount } = renderHook(() =>
@@ -435,10 +433,9 @@ describe("useUnicornScene", () => {
     addSceneMock.mockResolvedValue(scene);
 
     const props = defaultProps(elementRef);
-    const { rerender } = renderHook(
-      (p) => useUnicornScene(p),
-      { initialProps: props },
-    );
+    const { rerender } = renderHook((p) => useUnicornScene(p), {
+      initialProps: props,
+    });
 
     await act(async () => {});
     expect(addSceneMock).toHaveBeenCalledTimes(1);
@@ -580,5 +577,90 @@ describe("useUnicornScene", () => {
 
     expect(onError).toHaveBeenCalled();
     expect(result.current.error).toBeInstanceOf(Error);
+  });
+
+  // -----------------------------------------------------------------------
+  // ResizeObserver – container resize triggers scene.resize()
+  // -----------------------------------------------------------------------
+
+  it("calls scene.resize() when the container is resized", async () => {
+    const resizeFn = vi.fn();
+    const scene = createMockScene({ resize: resizeFn });
+    addSceneMock.mockResolvedValueOnce(scene);
+
+    renderHook(() => useUnicornScene(defaultProps(elementRef)));
+
+    await act(async () => {});
+
+    // Find the observer watching our container
+    const observer = MockResizeObserver.instances.find((o) =>
+      o.elements.has(containerEl),
+    );
+    expect(observer).toBeDefined();
+
+    // Simulate a container resize
+    act(() => {
+      observer!.simulateResize(containerEl);
+    });
+
+    expect(resizeFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("handles scene.resize being undefined gracefully", async () => {
+    const scene = createMockScene({ resize: undefined });
+    addSceneMock.mockResolvedValueOnce(scene);
+
+    renderHook(() => useUnicornScene(defaultProps(elementRef)));
+
+    await act(async () => {});
+
+    const observer = MockResizeObserver.instances.find((o) =>
+      o.elements.has(containerEl),
+    );
+
+    // Should not throw when resize is undefined
+    act(() => {
+      observer!.simulateResize(containerEl);
+    });
+  });
+
+  it("disconnects the ResizeObserver on unmount", async () => {
+    const scene = createMockScene({ resize: vi.fn() });
+    addSceneMock.mockResolvedValueOnce(scene);
+
+    const { unmount } = renderHook(() =>
+      useUnicornScene(defaultProps(elementRef)),
+    );
+
+    await act(async () => {});
+
+    const observer = MockResizeObserver.instances.find((o) =>
+      o.elements.has(containerEl),
+    );
+    expect(observer).toBeDefined();
+
+    unmount();
+
+    expect(observer!.disconnect).toHaveBeenCalled();
+  });
+
+  it("does not create a ResizeObserver when elementRef is null", async () => {
+    const instancesBefore = MockResizeObserver.instances.length;
+
+    renderHook(() =>
+      useUnicornScene({
+        ...defaultProps({ current: null }),
+        isScriptLoaded: true,
+      }),
+    );
+
+    await act(async () => {});
+
+    // No new observer should have been created for a null element
+    const newObservers = MockResizeObserver.instances.slice(instancesBefore);
+    const observersWithElements = newObservers.filter(
+      (o) => o.elements.size > 0,
+    );
+    expect(observersWithElements).toHaveLength(0);
   });
 });

--- a/src/shared/hooks.ts
+++ b/src/shared/hooks.ts
@@ -414,5 +414,21 @@ export function useUnicornScene({
     }
   }, [paused]);
 
+  // Observe container resize and call scene.resize() so the canvas adapts
+  useEffect(() => {
+    const el = elementRef.current;
+    if (!el) return;
+
+    const observer = new ResizeObserver(() => {
+      internalSceneRef.current?.resize?.();
+    });
+
+    observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [elementRef]);
+
   return { error: initError };
 }

--- a/src/shared/hooks.ts
+++ b/src/shared/hooks.ts
@@ -417,7 +417,7 @@ export function useUnicornScene({
   // Observe container resize and call scene.resize() so the canvas adapts
   useEffect(() => {
     const el = elementRef.current;
-    if (!el) return;
+    if (!el || typeof ResizeObserver === "undefined") return;
 
     const observer = new ResizeObserver(() => {
       internalSceneRef.current?.resize?.();


### PR DESCRIPTION
This pull request introduces comprehensive test coverage and implementation for handling container resizing in the `useUnicornScene` hook, ensuring that the scene properly responds to size changes. It includes a mock for `ResizeObserver` to enable reliable testing in the JSDOM environment, and adds several new tests to verify the resize behavior. Additionally, it refactors test code for improved readability and consistency.

**ResizeObserver support and testing:**

* Added a minimal `MockResizeObserver` implementation in `src/__tests__/setup.ts` to mock browser `ResizeObserver` behavior, enabling simulation of resize events in tests. (`src/__tests__/setup.ts`)
* Updated the `useUnicornScene` hook to observe container element resizes and call `scene.resize()` as needed, disconnecting the observer on unmount. (`src/shared/hooks.ts`)
* Added tests to verify that resizing the container triggers `scene.resize()`, handles the absence of a `resize` method gracefully, disconnects the observer on unmount, and does not create observers for null refs. (`src/__tests__/useUnicornScene.test.ts`)

**Test code refactoring and improvements:**

* Refactored multiple `renderHook` calls to use a consistent, more concise object form for `initialProps` and improved formatting for readability. (`src/__tests__/useUnicornScene.test.ts`) [[1]](diffhunk://#diff-7e57318b2c4d4ddd66ab2990de54a40a367441cdeab57b31ab0910e1050a58ddL138-R140) [[2]](diffhunk://#diff-7e57318b2c4d4ddd66ab2990de54a40a367441cdeab57b31ab0910e1050a58ddL163-R164) [[3]](diffhunk://#diff-7e57318b2c4d4ddd66ab2990de54a40a367441cdeab57b31ab0910e1050a58ddL282-R289) [[4]](diffhunk://#diff-7e57318b2c4d4ddd66ab2990de54a40a367441cdeab57b31ab0910e1050a58ddL310-R314) [[5]](diffhunk://#diff-7e57318b2c4d4ddd66ab2990de54a40a367441cdeab57b31ab0910e1050a58ddL340-R338) [[6]](diffhunk://#diff-7e57318b2c4d4ddd66ab2990de54a40a367441cdeab57b31ab0910e1050a58ddL438-R438)
* Ensured proper cleanup of `MockResizeObserver` instances after each test to avoid cross-test contamination. (`src/__tests__/useUnicornScene.test.ts`)
* Added import and usage of `MockResizeObserver` in the test suite. (`src/__tests__/useUnicornScene.test.ts`, `src/__tests__/useUnicornScene.test.ts`)
* Minor formatting improvements in test assertions and callbacks for clarity and consistency. (`src/__tests__/useUnicornScene.test.ts`, `src/__tests__/next-component.test.ts`) [[1]](diffhunk://#diff-7e57318b2c4d4ddd66ab2990de54a40a367441cdeab57b31ab0910e1050a58ddL106-R108) [[2]](diffhunk://#diff-7e57318b2c4d4ddd66ab2990de54a40a367441cdeab57b31ab0910e1050a58ddL209-R216) [[3]](diffhunk://#diff-7e57318b2c4d4ddd66ab2990de54a40a367441cdeab57b31ab0910e1050a58ddL229-R231) [[4]](diffhunk://#diff-c013d86f67242fb4eae23059728521b62d969f51672ad5785265932a42c4770aL60-R70)