### PR TITLE
fix: avoid scene initialization after Strict Mode cleanup

### DIFF
--- a/src/__tests__/useUnicornScene.test.ts
+++ b/src/__tests__/useUnicornScene.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
+import { StrictMode } from "react";
 import { useUnicornScene } from "../shared/hooks";
 import type { UnicornStudioScene } from "../shared/types";
 import { MockResizeObserver } from "./setup";
@@ -83,6 +84,20 @@ describe("useUnicornScene", () => {
 
     expect(addSceneMock).toHaveBeenCalledTimes(1);
     expect(result.current.error).toBeNull();
+  });
+
+  it("initializes once in Strict Mode", async () => {
+    const scene = createMockScene();
+    addSceneMock.mockResolvedValue(scene);
+
+    renderHook(() => useUnicornScene(defaultProps(elementRef)), {
+      wrapper: StrictMode,
+    });
+
+    await act(async () => {});
+
+    expect(addSceneMock).toHaveBeenCalledTimes(1);
+    expect(scene.destroy).not.toHaveBeenCalled();
   });
 
   it("does not initialize when isScriptLoaded is false", async () => {
@@ -486,6 +501,8 @@ describe("useUnicornScene", () => {
         preset: "Dark Theme",
       },
     });
+
+    await act(async () => {});
 
     // Props change while addScene() is still in flight, so the scene config was
     // already built with the previous values.

--- a/src/shared/hooks.ts
+++ b/src/shared/hooks.ts
@@ -409,6 +409,10 @@ export function useUnicornScene({
     async function initializeScene() {
       if (!elementRef.current || !isScriptLoaded || validationError) return;
 
+      // Let Strict Mode clean up its discarded effect before starting the SDK.
+      await Promise.resolve();
+      if (ignore) return;
+
       // Prevent multiple concurrent initializations
       if (isInitializingRef.current) return;
 


### PR DESCRIPTION
## Summary

- defer scene initialization by one microtask so React Strict Mode can clean up its discarded effect before `addScene()` starts
- skip initialization when that effect has already been cleaned up
- add a Strict Mode regression test that verifies the SDK initializes exactly once

## Why

In a Next.js App Router application, navigating client-side to a route containing a scene could trigger this SDK error:

```
TypeError: Cannot read properties of null (reading 'canvas')
    at setInitialFlattenedPlaneUniforms
```

The first Strict Mode effect started `addScene()` synchronously. React then cleaned up that discarded effect and the wrapper destroyed the scene, while asynchronous SDK initialization callbacks were still running. Those callbacks later accessed the destroyed scene's null `curtain`.

Yielding one microtask before touching the SDK lets the Strict Mode cleanup set `ignore`, preventing the discarded effect from starting a scene at all.

## Checks

- `npm test` — 124 passed
- `npm run lint`
- `npm run type-check`
- `npm run build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved scene initialization reliability when the app is rendered under React Strict Mode.
  - Prevented scenes from being initialized more than once or unintentionally destroyed during startup.
  - Improved handling when scene properties change while initialization is still in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->